### PR TITLE
No default plugins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ RUN yum install sudo -y && \
 FROM ds-base AS ds-service
 ARG TARGETARCH
 ARG PRODUCT_EDITION=
-ARG PRODUCT_URL=http://download.onlyoffice.com/install/documentserver/linux/onlyoffice-documentserver$PRODUCT_EDITION.$TARGETARCH.rpm
+ARG RELEASE_VERSION
+ARG PRODUCT_URL=https://download.onlyoffice.com/install/documentserver/linux/onlyoffice-documentserver$PRODUCT_EDITION$RELEASE_VERSION.$TARGETARCH.rpm
 ENV TARGETARCH=$TARGETARCH
 RUN useradd --no-create-home --shell /sbin/nologin nginx && \
     yum -y updateinfo && \
@@ -191,8 +192,7 @@ COPY --from=ds-service \
     /usr/lib64/libDjVuFile.so \
     /usr/lib64/libEpubFile.so \
     /usr/lib64/libFb2File.so \
-    /usr/lib64/libPdfReader.so \
-    /usr/lib64/libPdfWriter.so \
+    /usr/lib64/libPdfFile.so \
     /usr/lib64/libHtmlFile2.so \
     /usr/lib64/libHtmlRenderer.so \
     /usr/lib64/libUnicodeConverter.so \
@@ -252,10 +252,15 @@ ENTRYPOINT /var/www/onlyoffice/documentserver-example/docker-entrypoint.sh npm s
 FROM alpine:latest AS utils
 LABEL maintainer Ascensio System SIA <support@onlyoffice.com>
 RUN apk add bash postgresql-client mysql-client curl wget && \
+    curl -LO \
+      https://storage.googleapis.com/kubernetes-release/release/`curl \
+      -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl && \
+    chmod +x ./kubectl && \
+    mv ./kubectl /usr/local/bin/kubectl && \
     addgroup --system --gid 101 ds && \
     adduser --system -G ds -h /home/ds --shell /bin/bash --uid 101 ds && \
-    mkdir /sql && \
-    chown -R ds:ds /sql
+    mkdir /scripts && \
+    chown -R ds:ds /scripts
 USER ds
 
 FROM statsd/statsd AS metrics

--- a/Dockerfile.noplugins
+++ b/Dockerfile.noplugins
@@ -40,6 +40,7 @@ COPY --chown=ds:ds \
 COPY --chown=ds:ds \
     fonts/ \
     /var/www/$COMPANY_NAME/documentserver/core-fonts/custom/
+RUN rm -rf /var/www/$COMPANY_NAME/documentserver/sdkjs-plugins/*/
 COPY --chown=ds:ds \
     plugins/ \
     /var/www/$COMPANY_NAME/documentserver/sdkjs-plugins/
@@ -71,6 +72,9 @@ COPY --chown=ds:ds --from=ds-service \
     /var/www/$COMPANY_NAME/documentserver/sdkjs \
     /var/www/$COMPANY_NAME/documentserver/sdkjs
 COPY --chown=ds:ds --from=ds-service \
+    /var/www/$COMPANY_NAME/documentserver/sdkjs-plugins \
+    /var/www/$COMPANY_NAME/documentserver/sdkjs-plugins
+COPY --chown=ds:ds --from=ds-service \
     /var/www/$COMPANY_NAME/documentserver/web-apps \
     /var/www/$COMPANY_NAME/documentserver/web-apps
 COPY --from=ds-service \
@@ -99,7 +103,6 @@ RUN sed 's|\(application\/zip.*\)|\1\n    application\/wasm wasm;|' \
     ln -sf /dev/stderr /var/log/nginx/error.log && \
     mkdir -p \
         /var/lib/$COMPANY_NAME/documentserver/App_Data/cache/files \
-        /var/www/$COMPANY_NAME/documentserver/sdkjs-plugins \
         /var/lib/$COMPANY_NAME/documentserver/App_Data/docbuilder && \
     chown -R ds:ds /var/lib/$COMPANY_NAME/documentserver && \
     find \
@@ -109,6 +112,7 @@ RUN sed 's|\(application\/zip.*\)|\1\n    application\/wasm wasm;|' \
         -exec sh -c 'gzip -cf9 $0 > $0.gz && chown ds:ds $0.gz' {} \; && \
     find \
         /var/www/$COMPANY_NAME/documentserver/sdkjs \
+        /var/www/$COMPANY_NAME/documentserver/sdkjs-plugins \
         /var/www/$COMPANY_NAME/documentserver/web-apps \
         /var/www/$COMPANY_NAME/documentserver-example/welcome \
         -type f \
@@ -128,6 +132,9 @@ COPY --from=ds-service --chown=ds:ds \
     /etc/$COMPANY_NAME/documentserver/log4js/production.json \
     /etc/$COMPANY_NAME/documentserver/log4js/
 COPY --from=ds-service \
+    /var/www/$COMPANY_NAME/documentserver/sdkjs-plugins \
+    /var/www/$COMPANY_NAME/documentserver/sdkjs-plugins
+COPY --from=ds-service \
     /var/www/$COMPANY_NAME/documentserver/web-apps/apps/common/main/resources/themes \
     /var/www/$COMPANY_NAME/documentserver/web-apps/apps/common/main/resources/themes
 COPY --from=ds-service \
@@ -143,7 +150,6 @@ COPY --from=ds-service \
     /var/www/$COMPANY_NAME/documentserver/document-templates/new \
     /var/www/$COMPANY_NAME/documentserver/document-templates/new
 COPY docker-entrypoint.sh /usr/local/bin/
-RUN mkdir -p /var/www/$COMPANY_NAME/documentserver/sdkjs-plugins
 USER ds
 ENTRYPOINT docker-entrypoint.sh /var/www/$COMPANY_NAME/documentserver/server/DocService/docservice
 HEALTHCHECK --interval=10s --timeout=3s CMD curl -sf http://localhost:8000/index.html


### PR DESCRIPTION
This PR aims to fix and close #69 . It is currently applying modifications to all the images without using inheritance and it is also not working (sdkjs-plugins folder appears empty).

Removing only the content of sdkjs-plugins directory, except for js and css file, in `ds-service` will remove default plugin and also disable plugin manager.