### PR TITLE
Add non-plugin build into the action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,7 +49,7 @@ jobs:
         run: |
           echo "source-tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
 
-      - name: Build Community-Edition
+      - name: "Build Docs${{ matrix.edition }}"
         env:
            SOURCE_TAG: ${{ steps.tag-name.outputs.source-tag }}
            NOPLUG_POSTFIX: ${{ matrix.postfix }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,15 +8,26 @@ on:
       
 jobs:
   build:
-    name: Build 
+    name: "${{ matrix.name }} ${{ matrix.edition }}"
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
+        name: ["Build Docs"]
+        dockerfile: ["Dockerfile"]
         edition: [ "", "-ee", "-de"]
         images: [ "proxy docservice converter" ]
         include:
+          - edition: "-de"
+            name: "Build Docs non-plugins"
+            dockerfile: "Dockerfile.noplugins"
+            images: "proxy docservice converter"
+            postfix: "-noplugins"
+
           - edition: ""
-            images: "example utils" 
+            name: "Build utils"
+            dockerfile: "Dockerfile"
+            images: "example utils"
     steps:
       - name: Checkout code 
         uses: actions/checkout@v3
@@ -41,9 +52,12 @@ jobs:
       - name: Build Community-Edition
         env:
            SOURCE_TAG: ${{ steps.tag-name.outputs.source-tag }}
+           NOPLUG_POSTFIX: ${{ matrix.postfix }}
+           DOCKERFILE: ${{ matrix.dockerfile }}
         run: |
           DOCKER_TAG=$(echo ${SOURCE_TAG} | sed 's/^.//')
-          PRODUCT_EDITION=${{ matrix.edition }} TAG=$DOCKER_TAG \
+          PRODUCT_EDITION=${{ matrix.edition }} \
+          TAG=$DOCKER_TAG \
             docker buildx bake \
             -f docker-bake.hcl ${{ matrix.images }} \
             --push

--- a/Dockerfile.noplugins
+++ b/Dockerfile.noplugins
@@ -1,0 +1,257 @@
+FROM amazonlinux:2 AS ds-base
+
+LABEL maintainer Ascensio System SIA <support@onlyoffice.com>
+
+ARG COMPANY_NAME=onlyoffice
+ENV COMPANY_NAME=$COMPANY_NAME \
+    NODE_ENV=production-linux \
+    NODE_CONFIG_DIR=/etc/$COMPANY_NAME/documentserver
+
+RUN yum install sudo -y && \
+    yum install shadow-utils -y && \
+    amazon-linux-extras install epel -y && \
+    yum install procps-ng tar -y && \
+    groupadd --system --gid 101 ds && \
+    useradd --system -g ds --no-create-home --shell /sbin/nologin --uid 101 ds && \
+    rm -f /var/log/*log
+
+FROM ds-base AS ds-service
+ARG TARGETARCH
+ARG PRODUCT_EDITION=
+ARG RELEASE_VERSION
+ARG PRODUCT_URL=https://download.onlyoffice.com/install/documentserver/linux/onlyoffice-documentserver$PRODUCT_EDITION$RELEASE_VERSION.$TARGETARCH.rpm
+ENV TARGETARCH=$TARGETARCH
+WORKDIR /ds
+RUN useradd --no-create-home --shell /sbin/nologin nginx && \
+    yum -y updateinfo && \
+    yum -y install cabextract fontconfig xorg-x11-font-utils xorg-x11-server-utils wget rpm2cpio && \
+    rpm -i https://downloads.sourceforge.net/project/mscorefonts2/rpms/msttcore-fonts-installer-2.6-1.noarch.rpm && \
+    PRODUCT_URL=$(echo $PRODUCT_URL | sed "s/"$TARGETARCH"/"$(uname -m)"/g") && \
+    PACKAGE_NAME=$(basename "$PRODUCT_URL") && \
+    wget $PRODUCT_URL && \
+    rpm -ivh $PACKAGE_NAME --noscripts --nodeps && \
+    rpm2cpio $PACKAGE_NAME | cpio -idmv ./usr/lib64/* && \
+    mkdir -p /var/www/$COMPANY_NAME/documentserver/core-fonts/msttcore && \
+    cp -vt \
+        /var/www/$COMPANY_NAME/documentserver/core-fonts/msttcore \
+        /usr/share/fonts/msttcore/*.ttf && \
+    chmod a+r /etc/$COMPANY_NAME/documentserver*/*.json && \
+    chmod a+r /etc/$COMPANY_NAME/documentserver/log4js/*.json
+COPY --chown=ds:ds \
+    config/nginx/includes/http-common.conf \
+    config/nginx/includes/http-upstream.conf \
+    /etc/$COMPANY_NAME/documentserver/nginx/includes/
+COPY --chown=ds:ds \
+    fonts/ \
+    /var/www/$COMPANY_NAME/documentserver/core-fonts/custom/
+COPY --chown=ds:ds \
+    plugins/ \
+    /var/www/$COMPANY_NAME/documentserver/sdkjs-plugins/
+RUN documentserver-generate-allfonts.sh true
+
+FROM ds-base AS proxy
+ENV DOCSERVICE_HOST_PORT=localhost:8000 \
+    EXAMPLE_HOST_PORT=localhost:3000 \
+    NGINX_ACCESS_LOG=off \
+    NGINX_GZIP_PROXIED=off \
+    NGINX_WORKER_CONNECTIONS=4096
+EXPOSE 8888
+RUN yum -y updateinfo && \
+    yum -y install gettext nginx && \
+    yum clean all && \
+    rm -f /var/log/*log
+COPY --chown=ds:ds config/nginx/nginx.conf /etc/nginx/nginx.conf
+COPY --chown=ds:ds proxy-docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+COPY --chown=ds:ds --chmod=644 --from=ds-service \
+    /etc/$COMPANY_NAME/documentserver/nginx/ds.conf \
+    /etc/nginx/conf.d/
+COPY --chown=ds:ds --chmod=644 --from=ds-service \
+    /etc/$COMPANY_NAME/documentserver*/nginx/includes/*.conf \
+    /etc/nginx/includes/
+COPY --chown=ds:ds --from=ds-service \
+    /var/www/$COMPANY_NAME/documentserver/fonts \
+    /var/www/$COMPANY_NAME/documentserver/fonts
+COPY --chown=ds:ds --from=ds-service \
+    /var/www/$COMPANY_NAME/documentserver/sdkjs \
+    /var/www/$COMPANY_NAME/documentserver/sdkjs
+COPY --chown=ds:ds --from=ds-service \
+    /var/www/$COMPANY_NAME/documentserver/web-apps \
+    /var/www/$COMPANY_NAME/documentserver/web-apps
+COPY --from=ds-service \
+    /var/www/$COMPANY_NAME/documentserver/dictionaries \
+    /var/www/$COMPANY_NAME/documentserver/dictionaries
+COPY --from=ds-service \
+    /var/www/$COMPANY_NAME/documentserver/document-templates/new \
+    /var/www/$COMPANY_NAME/documentserver/document-templates/new
+COPY --chown=ds:ds --from=ds-service \
+    /var/www/$COMPANY_NAME/documentserver-example/welcome \
+    /var/www/$COMPANY_NAME/documentserver-example/welcome
+RUN sed 's|\(application\/zip.*\)|\1\n    application\/wasm wasm;|' \
+        -i /etc/nginx/mime.types && \
+    sed 's,\(listen.\+:\)\([0-9]\+\)\(.*;\),'"\18888\3"',' \
+        -i /etc/nginx/conf.d/ds.conf && \
+    sed '/access_log.*/d' -i /etc/nginx/includes/ds-common.conf && \
+    sed '/error_log.*/d' -i /etc/nginx/includes/ds-common.conf && \
+    echo -e "\ngzip_proxied \$NGINX_GZIP_PROXIED;\n" >> /etc/nginx/includes/ds-common.conf && \
+    sed 's/#*\s*\(gzip_static\).*/\1 on;/g' -i /etc/nginx/includes/ds-docservice.conf && \
+    sed -i 's/etc\/nginx/tmp\/proxy_nginx/g' /etc/nginx/nginx.conf && \
+    sed -i 's/etc\/nginx/tmp\/proxy_nginx/g' /etc/nginx/conf.d/ds.conf && \
+    sed 's/\(X-Forwarded-For\).*/\1 example.com;/' -i /etc/nginx/includes/ds-example.conf && \
+    sed 's/\(index\).*/\1 k8s.html;/' -i /etc/nginx/includes/ds-example.conf && \
+    chmod 755 /var/log/nginx && \
+    ln -sf /dev/stdout /var/log/nginx/access.log && \
+    ln -sf /dev/stderr /var/log/nginx/error.log && \
+    mkdir -p \
+        /var/lib/$COMPANY_NAME/documentserver/App_Data/cache/files \
+        /var/www/$COMPANY_NAME/documentserver/sdkjs-plugins \
+        /var/lib/$COMPANY_NAME/documentserver/App_Data/docbuilder && \
+    chown -R ds:ds /var/lib/$COMPANY_NAME/documentserver && \
+    find \
+        /var/www/$COMPANY_NAME/documentserver/fonts \
+        -type f ! \
+        -name "*.*" \
+        -exec sh -c 'gzip -cf9 $0 > $0.gz && chown ds:ds $0.gz' {} \; && \
+    find \
+        /var/www/$COMPANY_NAME/documentserver/sdkjs \
+        /var/www/$COMPANY_NAME/documentserver/web-apps \
+        /var/www/$COMPANY_NAME/documentserver-example/welcome \
+        -type f \
+        \( -name *.js -o -name *.json -o -name *.htm -o -name *.html -o -name *.css \) \
+        -exec sh -c 'gzip -cf9 $0 > $0.gz && chown ds:ds $0.gz' {} \;
+VOLUME /var/lib/$COMPANY_NAME
+USER ds
+ENTRYPOINT docker-entrypoint.sh
+
+FROM ds-base AS docservice
+EXPOSE 8000
+COPY --from=ds-service \
+    /etc/$COMPANY_NAME/documentserver/default.json \
+    /etc/$COMPANY_NAME/documentserver/production-linux.json \
+    /etc/$COMPANY_NAME/documentserver/
+COPY --from=ds-service --chown=ds:ds \
+    /etc/$COMPANY_NAME/documentserver/log4js/production.json \
+    /etc/$COMPANY_NAME/documentserver/log4js/
+COPY --from=ds-service \
+    /var/www/$COMPANY_NAME/documentserver/web-apps/apps/common/main/resources/themes \
+    /var/www/$COMPANY_NAME/documentserver/web-apps/apps/common/main/resources/themes
+COPY --from=ds-service \
+    /var/www/$COMPANY_NAME/documentserver/server/DocService \
+    /var/www/$COMPANY_NAME/documentserver/server/DocService
+COPY --from=ds-service \
+    /var/www/$COMPANY_NAME/documentserver/server/info \
+    /var/www/$COMPANY_NAME/documentserver/server/info
+COPY --chown=ds:ds --from=ds-service \
+    /var/www/$COMPANY_NAME/documentserver/web-apps/apps/api/wopi \
+    /var/www/$COMPANY_NAME/documentserver/web-apps/apps/api/wopi
+COPY --from=ds-service \
+    /var/www/$COMPANY_NAME/documentserver/document-templates/new \
+    /var/www/$COMPANY_NAME/documentserver/document-templates/new
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN mkdir -p /var/www/$COMPANY_NAME/documentserver/sdkjs-plugins
+USER ds
+ENTRYPOINT docker-entrypoint.sh /var/www/$COMPANY_NAME/documentserver/server/DocService/docservice
+HEALTHCHECK --interval=10s --timeout=3s CMD curl -sf http://localhost:8000/index.html
+
+FROM ds-base AS converter
+COPY --from=ds-service \
+    /etc/$COMPANY_NAME/documentserver/default.json \
+    /etc/$COMPANY_NAME/documentserver/production-linux.json \
+    /etc/$COMPANY_NAME/documentserver/
+COPY --from=ds-service --chown=ds:ds \
+    /etc/$COMPANY_NAME/documentserver/log4js/production.json \
+    /etc/$COMPANY_NAME/documentserver/log4js/
+COPY --from=ds-service \
+    /var/www/$COMPANY_NAME/documentserver/core-fonts \
+    /var/www/$COMPANY_NAME/documentserver/core-fonts
+COPY --from=ds-service \
+    /var/www/$COMPANY_NAME/documentserver/fonts \
+    /var/www/$COMPANY_NAME/documentserver/fonts
+COPY --from=ds-service \
+    /usr/share/fonts \
+    /usr/share/fonts
+COPY --from=ds-service \
+    /var/www/$COMPANY_NAME/documentserver/sdkjs \
+    /var/www/$COMPANY_NAME/documentserver/sdkjs
+COPY --from=ds-service \
+    /var/www/$COMPANY_NAME/documentserver/server/FileConverter \
+    /var/www/$COMPANY_NAME/documentserver/server/FileConverter
+COPY --from=ds-service \
+    /var/www/$COMPANY_NAME/documentserver/web-apps \
+    /var/www/$COMPANY_NAME/documentserver/web-apps
+COPY --from=ds-service \
+    /var/www/$COMPANY_NAME/documentserver/document-templates/new \
+    /var/www/$COMPANY_NAME/documentserver/document-templates/new
+COPY --from=ds-service \
+    /ds/usr/lib64/* \
+    /usr/lib64/
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN mkdir -p \
+        /var/lib/$COMPANY_NAME/documentserver/App_Data/cache/files \
+        /var/lib/$COMPANY_NAME/documentserver/App_Data/docbuilder && \
+    chown -R ds:ds /var/lib/$COMPANY_NAME/documentserver
+USER ds
+ENTRYPOINT docker-entrypoint.sh /var/www/$COMPANY_NAME/documentserver/server/FileConverter/converter
+
+FROM node:buster AS example
+LABEL maintainer Ascensio System SIA <support@onlyoffice.com>
+
+ENV LANG=en_US.UTF-8 \
+    LANGUAGE=en_US:en \
+    LC_ALL=en_US.UTF-8 \
+    NODE_ENV=production-linux \
+    NODE_CONFIG_DIR=/etc/onlyoffice/documentserver-example/
+
+WORKDIR /var/www/onlyoffice/documentserver-example/
+
+RUN git clone \
+      --depth 1 \
+      --recurse-submodules \
+      https://github.com/ONLYOFFICE/document-server-integration.git && \
+    mkdir -p /var/www/onlyoffice/documentserver-example && \
+    cp -r ./document-server-integration/web/documentserver-example/nodejs/. \
+      /var/www/onlyoffice/documentserver-example/ && \
+    rm -rf ./document-server-integration && \
+    groupadd --system --gid 1001 ds && \
+    useradd \
+      --system \
+      -g ds \
+      --home-dir /var/www/onlyoffice/documentserver-example \
+      --create-home \
+      --shell /sbin/nologin \
+      --uid 1001 ds && \
+    chown -R ds:ds /var/www/onlyoffice/documentserver-example/ && \
+    mkdir -p /var/lib/onlyoffice/documentserver-example/ && \
+    chown -R ds:ds /var/lib/onlyoffice/ && \
+    mv files /var/lib/onlyoffice/documentserver-example/ && \
+    mkdir -p /etc/onlyoffice/documentserver-example/ && \
+    chown -R ds:ds /etc/onlyoffice/ && \
+    mv config/* /etc/onlyoffice/documentserver-example/ && \
+    npm install
+
+EXPOSE 3000
+
+USER ds
+
+ENTRYPOINT /var/www/onlyoffice/documentserver-example/docker-entrypoint.sh npm start
+
+FROM alpine:latest AS utils
+LABEL maintainer Ascensio System SIA <support@onlyoffice.com>
+RUN apk add bash postgresql-client mysql-client curl wget && \
+    curl -LO \
+      https://storage.googleapis.com/kubernetes-release/release/`curl \
+      -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl && \
+    chmod +x ./kubectl && \
+    mv ./kubectl /usr/local/bin/kubectl && \
+    addgroup --system --gid 101 ds && \
+    adduser --system -G ds -h /home/ds --shell /bin/bash --uid 101 ds && \
+    mkdir /scripts && \
+    chown -R ds:ds /scripts
+USER ds
+
+FROM statsd/statsd AS metrics
+ARG COMPANY_NAME=onlyoffice
+COPY --from=ds-service /var/www/$COMPANY_NAME/documentserver/server/Metrics/config/config.js /usr/src/app/config.js
+
+FROM postgres:9.5 AS db
+ARG COMPANY_NAME=onlyoffice
+COPY --from=ds-service /var/www/$COMPANY_NAME/documentserver/server/schema/postgresql/createdb.sql /docker-entrypoint-initdb.d/

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -15,12 +15,21 @@ variable "PRODUCT_EDITION" {
     default = ""
 }
 
+variable "DOCKERFILE" {
+    default = "Dockerfile"
+}
+
+variable "NOPLUG_POSTFIX" {
+    default = ""
+}
+
 group "apps" {
     targets = ["proxy", "converter", "docservice", "example"]
 }
 
 target "example" {
     target = "example"
+    dockerfile = "${DOCKERFILE}"
     tags = ["docker.io/${COMPANY_NAME}/${PREFIX_NAME}-example${PRODUCT_EDITION}:${TAG}"]
     platforms = ["linux/amd64", "linux/arm64"]
     args = {
@@ -30,7 +39,8 @@ target "example" {
 
 target "proxy" {
     target = "proxy"
-    tags = ["docker.io/${COMPANY_NAME}/${PREFIX_NAME}-proxy${PRODUCT_EDITION}:${TAG}"]
+    dockerfile = "${DOCKERFILE}"
+    tags = ["docker.io/${COMPANY_NAME}/${PREFIX_NAME}-proxy${PRODUCT_EDITION}:${TAG}${NOPLUG_POSTFIX}"]
     platforms = ["linux/amd64", "linux/arm64"]
     args = {
         "PRODUCT_EDITION": "${PRODUCT_EDITION}"
@@ -38,8 +48,9 @@ target "proxy" {
 }
 
 target "converter" {
-    target = "converter"  
-    tags = ["docker.io/${COMPANY_NAME}/${PREFIX_NAME}-converter${PRODUCT_EDITION}:${TAG}"] 
+    target = "converter"
+    dockerfile = "${DOCKERFILE}"
+    tags = ["docker.io/${COMPANY_NAME}/${PREFIX_NAME}-converter${PRODUCT_EDITION}:${TAG}${NOPLUG_POSTFIX}"]
     platforms = ["linux/amd64", "linux/arm64"]
     args = {
         "PRODUCT_EDITION": "${PRODUCT_EDITION}"
@@ -47,8 +58,9 @@ target "converter" {
 }
 
 target "docservice" {
-    target = "docservice" 
-    tags = ["docker.io/${COMPANY_NAME}/${PREFIX_NAME}-docservice${PRODUCT_EDITION}:${TAG}"]
+    target = "docservice"
+    dockerfile = "${DOCKERFILE}"
+    tags = ["docker.io/${COMPANY_NAME}/${PREFIX_NAME}-docservice${PRODUCT_EDITION}:${TAG}${NOPLUG_POSTFIX}"]
     platforms = ["linux/amd64", "linux/arm64"]
     args = {
         "PRODUCT_EDITION": "${PRODUCT_EDITION}"
@@ -57,6 +69,7 @@ target "docservice" {
 
 target "utils" {
     target = "utils"
+    dockerfile = "${DOCKERFILE}"
     tags = ["docker.io/${COMPANY_NAME}/${PREFIX_NAME}-utils:${TAG}"]
     platforms = ["linux/amd64", "linux/arm64"]
 }


### PR DESCRIPTION
Several variables have been added to the build configuration:

- The DOCKERFILE variable is needed to dynamically determine which dockerfile will be used for the build.
- The NOPLUG_POSTFIX was added to the build tag to push images without plugins to the specific repository. 

Added a matrix for building versions without plugins. Also added a name for matrices for a more visual result.

Important: 
_**Was added fail-fast field with [`false`](https://github.com/ONLYOFFICE/Docker-Docs/pull/95/files#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1R14) value. So that when one of the parallel build crashes, the rest continue to build if possible**_