### PR TITLE
Update download location of stable kubectl release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -289,7 +289,7 @@ RUN apt update && \
     ACCEPT_EULA=Y apt install -y postgresql-client-17 default-mysql-client mssql-tools18 unixodbc-dev && \
     curl -LO \
     https://dl.k8s.io/release/`curl \
-      -L -s https://dl.k8s.io/release/stable.txt`/bin/linux/amd64/kubectl && \
+      -L -s https://dl.k8s.io/release/stable.txt`/bin/linux/${TARGETARCH}/kubectl && \
     chmod +x ./kubectl && \
     mv ./kubectl /usr/local/bin/kubectl && \
     mkdir -p ~/oracle/instantclient && \

--- a/Dockerfile.noplugins
+++ b/Dockerfile.noplugins
@@ -278,7 +278,7 @@ RUN apt update && \
     ACCEPT_EULA=Y apt install -y postgresql-client-17 default-mysql-client mssql-tools18 unixodbc-dev && \
     curl -LO \
     https://dl.k8s.io/release/`curl \
-      -L -s https://dl.k8s.io/release/stable.txt`/bin/linux/amd64/kubectl && \
+      -L -s https://dl.k8s.io/release/stable.txt`/bin/linux/${TARGETARCH}/kubectl && \
     chmod +x ./kubectl && \
     mv ./kubectl /usr/local/bin/kubectl && \
     mkdir -p ~/oracle/instantclient && \


### PR DESCRIPTION
storage.googleapis.com is no longer the correct location for kubernetes downloads and hasn't been updated for quite some time. This will update kubectl from v1.31.0 -> v1.34.1.

I've also updated the URL to download the correct binary for the target platform architecture.

See kubernetes/kubernetes#117949